### PR TITLE
Fix incorrect contract name

### DIFF
--- a/tests/template-example.test.ts
+++ b/tests/template-example.test.ts
@@ -12,7 +12,7 @@ const address1 = accounts.get("wallet_1")!;
 describe("example tests", () => {
   it("works when we call the proxy directly", () => {
     const receipt = simnet.callPublicFn(
-      `${address1}.template-example`,
+      `template-example`,
       "mint",
       [Cl.uint(100), Cl.principal(address1)],
       address1
@@ -21,7 +21,7 @@ describe("example tests", () => {
   });
   it("fails when we call the proxy that uses a constant", () => {
     const receipt = simnet.callPublicFn(
-      `${address1}.template-example`,
+      `template-example`,
       "mint",
       [Cl.uint(100), Cl.principal(address1)],
       address1

--- a/tests/template-example.test.ts
+++ b/tests/template-example.test.ts
@@ -19,10 +19,21 @@ describe("example tests", () => {
     );
     expect(receipt.result).toBeOk(Cl.bool(true));
   });
+ 
   it("fails when we call the proxy that uses a constant", () => {
     const receipt = simnet.callPublicFn(
       `template-example`,
-      "mint",
+      "mint-template-sugared",
+      [Cl.uint(100), Cl.principal(address1)],
+      address1
+    );
+    expect(receipt.result).toBeErr(Cl.uint(1));
+  });
+
+  it("fails when we call the proxy that uses a constant (2)", () => {
+    const receipt = simnet.callPublicFn(
+      `template-example`,
+      "mint-template-full",
       [Cl.uint(100), Cl.principal(address1)],
       address1
     );


### PR DESCRIPTION
This PR
* removes the contract address from calls in unit tests.
* makes the repo demonstrate the issue with contract calls with constants in unit tests